### PR TITLE
refactor: removes useless SingleColorCapture._outlet

### DIFF
--- a/example/hello_jetson
+++ b/example/hello_jetson
@@ -37,19 +37,6 @@ class SingleColorCapture(Producer):
             if self._outlet(frame):
                 self.frames.append(frame)
 
-    def _outlet(self, o):
-        length = len(self.out_queues)
-        while self._is_running():
-            try:
-                self.out_queues[self.out_queue_id].put(o, block=False)
-                self.out_queue_id = (self.out_queue_id + 1) % length
-                return True
-            except Full:
-                return False
-            except:
-                traceback.print_exc()
-        return False
-
 
 class Presenter(Consumer):
 


### PR DESCRIPTION
It has the same definition with base class.

Tested with Jetson Nano.