### PR TITLE
bugfix: actfw-jetson does not export __version__

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
           name: Check if git tag name is appropriate for package version
           command: |
             export TAG=$(echo ${CIRCLE_TAG} |sed -e 's/release-//')
-            export VERSION=$(poetry run python -c 'import actfw_jetson; print(actfw_jetson.__version__)')
+            export VERSION=$(poetry run python -c 'import pkg_resources; print(pkg_resources.get_distribution("actfw-jetson").version)')
             echo "Git tag: $TAG"
             echo "Package version: $VERSION"
             test "$VERSION" = "$TAG"


### PR DESCRIPTION
Fixes failing release CI job: https://app.circleci.com/pipelines/github/Idein/actfw-jetson/79/workflows/7e3c7329-750b-4b9b-835c-34ec2dbdb7a9/jobs/319