### PR TITLE
bugfix: workind directory was wrong (should be in repository root)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,8 +170,8 @@ jobs:
           at: /tmp/workspace
       - run:
           name: Publish wheel & sdist to PyPI
-          working_directory: /tmp/workspace
           command: |
+            mv /tmp/workspace/dist .
             poetry publish --username "__token__" --password "$PYPI_API_TOKEN" --no-interaction
 
 workflows:


### PR DESCRIPTION
May fix failing release CI job: https://app.circleci.com/pipelines/github/Idein/actfw-jetson/82/workflows/4075fec5-7293-4463-96bb-5993006a0bea/jobs/333