### PR TITLE
refactor: Reduce dependencies in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
           command: |
             apt-get update
             apt-get install -y --no-install-recommends ca-certificates python3-pip
-            apt-get install -y --no-install-recommends libgstreamer1.0-dev libgirepository1.0-dev ibgstreamer-plugins-base1.0-dev libglib2.0-dev libcairo2-dev
+            apt-get install -y --no-install-recommends libgstreamer1.0-dev libgirepository1.0-dev libglib2.0-dev libcairo2-dev
   poetry-install:
     steps:
       # See: https://circleci.com/docs/2.0/language-python/#cache-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
           command: |
             apt-get update
             apt-get install -y --no-install-recommends ca-certificates python3-pip
-            apt-get install -y --no-install-recommends libgstreamer1.0-dev libgirepository1.0-dev libglib2.0-dev libcairo2-dev
+            apt-get install -y --no-install-recommends libgstreamer1.0-dev libgirepository1.0-dev
   poetry-install:
     steps:
       # See: https://circleci.com/docs/2.0/language-python/#cache-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ commands:
           name: Install python dev tools and dependencies
           command: |
             apt-get update
-            apt-get install -y ca-certificates python3-pip
-            apt-get install -y libgstreamer1.0-dev libgirepository1.0-dev ibgstreamer-plugins-base1.0-dev libglib2.0-dev libcairo2-dev
+            apt-get install -y --no-install-recommends ca-certificates python3-pip
+            apt-get install -y --no-install-recommends libgstreamer1.0-dev libgirepository1.0-dev ibgstreamer-plugins-base1.0-dev libglib2.0-dev libcairo2-dev
   poetry-install:
     steps:
       # See: https://circleci.com/docs/2.0/language-python/#cache-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ commands:
           name: Install python dev tools and dependencies
           command: |
             apt-get update
-            apt-get install -y --no-install-recommends ca-certificates python3-pip
+            apt-get install -y --no-install-recommends python3-pip
             apt-get install -y --no-install-recommends libgstreamer1.0-dev libgirepository1.0-dev
   poetry-install:
     steps:


### PR DESCRIPTION
I guess these are necessary to run this package actually but unnecessary for CI.
(Especially, `ibgstreamer-plugins-base1.0-dev` is typo.)
