### PR TITLE
chore: Remove not reasonable use of different email address

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Configure git user
           command: |
-            git config user.email "bot+actfw-jetson-ci@idein.jp"
+            git config user.email "bot@idein.jp"
             git config user.name "ideinbot"
       - add_ssh_keys:
           fingerprints:


### PR DESCRIPTION
We want to use almost the same CI config for actfw-* repositories.
We don't need to use different email addresses.